### PR TITLE
Fix numbered list rendering

### DIFF
--- a/src/block.tsx
+++ b/src/block.tsx
@@ -51,7 +51,7 @@ interface Block {
 }
 
 export const Block: React.FC<Block> = props => {
-  const { block, parentBlock, children } = props;
+  const { block, children } = props;
   const blockValue = block?.value;
   switch (blockValue.type) {
     case "page":
@@ -90,33 +90,20 @@ export const Block: React.FC<Block> = props => {
       );
     case "bulleted_list":
     case "numbered_list":
-      const isTopLevel = block.value.type !== parentBlock.value.type;
-
-      const wrapList = (content: React.ReactNode) =>
-        blockValue.type === "bulleted_list" ? (
-          <ul className="notion-list notion-list-disc">{content}</ul>
-        ) : (
-          <ol className="notion-list notion-list-numbered">{content}</ol>
-        );
-
       let output: JSX.Element | null = null;
 
-      if (blockValue.content) {
-        output = (
-          <>
-            {blockValue.properties && (
-              <li>{renderChildText(blockValue.properties.title)}</li>
-            )}
-            {wrapList(children)}
-          </>
-        );
-      } else {
-        output = blockValue.properties ? (
-          <li>{renderChildText(blockValue.properties.title)}</li>
-        ) : null;
-      }
+      output = blockValue.properties ? (
+        <>
+          <li>
+            {renderChildText(blockValue.properties.title)}
+            {children}
+          </li>
+        </>
+      ) : (
+        <>{React.Children.count(children) > 0 && <li>{children}</li>}</>
+      );
 
-      return isTopLevel ? wrapList(output) : output;
+      return output;
 
     case "image":
     case "embed":

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { BlockMapType } from "./types";
 import { Block } from "./block";
+import { reduceBlockGroups, BlockGroup } from "./utils";
 
 interface NotionRendererProps {
   blockMap: BlockMapType;
@@ -24,14 +25,32 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
       block={currentBlock}
       parentBlock={parentBlock}
     >
-      {currentBlock?.value?.content?.map(contentId => (
-        <NotionRenderer
-          key={contentId}
-          currentId={contentId}
-          blockMap={blockMap}
-          level={level + 1}
-        />
-      ))}
+      {currentBlock?.value?.content
+        ?.reduce<Array<string | BlockGroup>>(
+          reduceBlockGroups(blockMap, level),
+          []
+        )
+        .map(contentIdOrGroup =>
+          typeof contentIdOrGroup === "string" ? (
+            <NotionRenderer
+              key={contentIdOrGroup}
+              currentId={contentIdOrGroup}
+              blockMap={blockMap}
+              level={level + 1}
+            />
+          ) : (
+            <contentIdOrGroup.wrapper>
+              {contentIdOrGroup.blockIds.map(contentId => (
+                <NotionRenderer
+                  key={contentId}
+                  currentId={contentId}
+                  blockMap={blockMap}
+                  level={level + 1}
+                />
+              ))}
+            </contentIdOrGroup.wrapper>
+          )
+        )}
     </Block>
   );
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,0 @@
-import { DecorationType } from "./types";
-
-export const classNames = (...classes: Array<string | undefined | false>) =>
-  classes.filter(a => !!a).join(" ");
-
-export const getTextContent = (text: DecorationType[]) => {
-  return text.reduce((prev, current) => prev + current[0], "");
-};

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -34,7 +34,7 @@ export const reduceBlockGroups = (blockMap: BlockMapType, level: number) => (
       break;
     case "bulleted_list":
       wrapper = (props: any) => (
-        <ol className="notion-list notion-list-disc" {...props} />
+        <ul className="notion-list notion-list-disc" {...props} />
       );
       break;
     default:

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,0 +1,70 @@
+import { DecorationType, BlockValueType, BlockMapType } from "./types";
+import React, { ComponentType } from "react";
+
+export const classNames = (...classes: Array<string | undefined | false>) =>
+  classes.filter(a => !!a).join(" ");
+
+export const getTextContent = (text: DecorationType[]) => {
+  return text.reduce((prev, current) => prev + current[0], "");
+};
+
+export interface BlockGroup {
+  type: BlockValueType["type"];
+  wrapper: string | ComponentType;
+  blockIds: string[];
+  level: number;
+}
+
+const groupedTypes = ["bulleted_list", "numbered_list"];
+export const reduceBlockGroups = (blockMap: BlockMapType, level: number) => (
+  contentIdList: Array<string | BlockGroup>,
+  currentId: string
+) => {
+  const currentType = blockMap[currentId]?.value?.type;
+  if (!groupedTypes.includes(currentType)) {
+    contentIdList.push(currentId);
+    return contentIdList;
+  }
+  let wrapper: ComponentType;
+  switch (currentType) {
+    case "numbered_list":
+      wrapper = (props: any) => (
+        <ol className="notion-list notion-list-numbered" {...props} />
+      );
+      break;
+    case "bulleted_list":
+      wrapper = (props: any) => (
+        <ol className="notion-list notion-list-disc" {...props} />
+      );
+      break;
+    default:
+      throw new Error(`Type ${currentType} has no specified wrapper`);
+  }
+
+  const lastIdIndex = contentIdList.length - 1;
+  if (lastIdIndex < 0 || typeof contentIdList[lastIdIndex] === "string") {
+    contentIdList.push({
+      type: currentType,
+      wrapper,
+      blockIds: [currentId],
+      level
+    });
+    return contentIdList;
+  }
+  const lastContentIdListItem = contentIdList[lastIdIndex] as BlockGroup;
+
+  if (
+    lastContentIdListItem.type === currentType &&
+    lastContentIdListItem.level === level
+  ) {
+    lastContentIdListItem.blockIds.push(currentId);
+  } else {
+    contentIdList.push({
+      type: currentType,
+      wrapper,
+      blockIds: [currentId],
+      level
+    });
+  }
+  return contentIdList;
+};


### PR DESCRIPTION
fixes #4.

**Before**

<img width="264" alt="image" src="https://user-images.githubusercontent.com/3087225/82217025-d2d0fb80-98e7-11ea-99d5-d0c630082e7d.png">

(Notice that only child numbering is correct)

**After**

<img width="262" alt="image" src="https://user-images.githubusercontent.com/3087225/82215858-027f0400-98e6-11ea-88f9-c7510fb3e696.png">


The current way numbered lists are rendered resulted in every list item being wrapped in an `ol`. This is likely due to the weird way notion renders these number lists. 

A list isn't actually hierarchical as one might expect. There isn't a top level list block that contains sub block entries. Rather notion just infers that grouped numbered list items on the same level are related to the same group. 

To achieve this I updated the logic of the `NotionRenderer` to have a reducer that goes over a block's child content and groups list items into what I've termed as a `BlockGroup`. A `BlockGroup` can specify it's own wrapper (like ul or ol) to group related items in. 

I'll comment more in line.