### PR TITLE
Preserve count order in numbered lists

### DIFF
--- a/src/block.tsx
+++ b/src/block.tsx
@@ -91,12 +91,15 @@ export const Block: React.FC<Block> = props => {
     case "bulleted_list":
     case "numbered_list":
       const isTopLevel = block.value.type !== parentBlock.value.type;
-
+      const itemPosition =
+        1 + (parentBlock.value.content?.indexOf(block.value.id) || 0);
       const wrapList = (content: React.ReactNode) =>
         blockValue.type === "bulleted_list" ? (
           <ul className="notion-list notion-list-disc">{content}</ul>
         ) : (
-          <ol className="notion-list notion-list-numbered">{content}</ol>
+          <ol start={itemPosition} className="notion-list notion-list-numbered">
+            {content}
+          </ol>
         );
 
       let output: JSX.Element | null = null;


### PR DESCRIPTION
Fixes #4

Use the `start` attribute of each `ol` element to render the correct count.