### PR TITLE
Add `fullPage` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,27 +93,29 @@ List of pages that implement this library.
 
 Most common block types are supported. We happily accept pull requests to add support for the missing blocks.
 
-| Block Type        | Supported  | Notes                |
-| ----------------- | ---------- | -------------------- |
-| Text              | ✅ Yes     |                      |
-| Heading           | ✅ Yes     |                      |
-| Image             | ✅ Yes     |                      |
-| Image Caption     | ✅ Yes     |                      |
-| Bulleted List     | ✅ Yes     |                      |
-| Numbered List     | ✅ Yes     |                      |
-| Quote             | ✅ Yes     |                      |
-| Callout           | ✅ Yes     |                      |
-| Column            | ✅ Yes     |                      |
-| iframe            | ✅ Yes     |                      |
-| Video             | ✅ Yes     | Only embedded videos |
-| Divider           | ✅ Yes     |                      |
-| Link              | ✅ Yes     |                      |
-| Code              | ✅ Yes     |                      |
-| Web Bookmark      | ✅ Yes     |                      |
-| Toggle List       | ✅ Yes     |                      |
-| Databases         | ❌ Missing |                      |
-| Checkbox          | ❌ Missing |                      |
-| Table Of Contents | ❌ Missing |                      |
+| Block Type        | Supported  | Notes                  |
+| ----------------- | ---------- | ---------------------- |
+| Text              | ✅ Yes     |                        |
+| Heading           | ✅ Yes     |                        |
+| Image             | ✅ Yes     |                        |
+| Image Caption     | ✅ Yes     |                        |
+| Bulleted List     | ✅ Yes     |                        |
+| Numbered List     | ✅ Yes     |                        |
+| Quote             | ✅ Yes     |                        |
+| Callout           | ✅ Yes     |                        |
+| Column            | ✅ Yes     |                        |
+| iframe            | ✅ Yes     |                        |
+| Video             | ✅ Yes     | Only embedded videos   |
+| Divider           | ✅ Yes     |                        |
+| Link              | ✅ Yes     |                        |
+| Code              | ✅ Yes     |                        |
+| Web Bookmark      | ✅ Yes     |                        |
+| Toggle List       | ✅ Yes     |                        |
+| Page Links        | ✅ Yes     |                        |
+| Header            | ✅ Yes     | Enable with `fullPage` |
+| Databases         | ❌ Missing |                        |
+| Checkbox          | ❌ Missing |                        |
+| Table Of Contents | ❌ Missing |                        |
 
 ## Credits
 

--- a/example/pages/[pageId].tsx
+++ b/example/pages/[pageId].tsx
@@ -35,24 +35,21 @@ const NotionPage = ({ blockMap }) => {
     blockMap[Object.keys(blockMap)[0]]?.value.properties.title[0][0];
 
   return (
-    <div
-      style={{
-        maxWidth: 708,
-        margin: "0 auto",
-        padding: "0 8px",
-        fontFamily: `-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol"`
-      }}
-    >
+    <>
       <Head>
         <title>{title}</title>
       </Head>
-      <NotionRenderer blockMap={blockMap} />
-      <style jsx>{`
+      <NotionRenderer blockMap={blockMap} fullPage />
+      <style jsx global>{`
         div :global(.notion-code) {
           box-sizing: border-box;
         }
+        body {
+          padding: 0;
+          margin: 0;
+        }
       `}</style>
-    </div>
+    </>
   );
 };
 

--- a/src/block.tsx
+++ b/src/block.tsx
@@ -85,6 +85,8 @@ export const Block: React.FC<Block> = props => {
             page_small_text
           } = blockValue.format || {};
 
+          const coverPosition = (1 - (page_cover_position || 0.5)) * 100;
+
           return (
             <div className="notion">
               {page_cover && (
@@ -93,9 +95,7 @@ export const Block: React.FC<Block> = props => {
                   alt={getTextContent(blockValue.properties.title)}
                   className="notion-page-cover"
                   style={{
-                    objectPosition: `center ${
-                      (1 - (page_cover_position || 0.5)) * 100
-                    }%`
+                    objectPosition: `center ${coverPosition}%`
                   }}
                 />
               )}

--- a/src/block.tsx
+++ b/src/block.tsx
@@ -1,8 +1,19 @@
 import * as React from "react";
-import { DecorationType, BlockType, ContentValueType } from "./types";
+import {
+  DecorationType,
+  BlockType,
+  ContentValueType,
+  BlockMapType
+} from "./types";
 import Asset from "./components/asset";
 import Code from "./components/code";
-import { classNames, getTextContent } from "./utils";
+import PageIcon from "./components/page-icon";
+import {
+  classNames,
+  getTextContent,
+  getListNumber,
+  toNotionImageUrl
+} from "./utils";
 
 export const renderChildText = (properties: DecorationType[]) => {
   return properties?.map(([text, decorations], i) => {
@@ -49,17 +60,73 @@ export type MapPageUrl = (pageId: string) => string;
 interface Block {
   block: BlockType;
   level: number;
-  listNumber?: number;
+  blockMap: BlockMapType;
+
+  fullPage?: boolean;
   mapPageUrl?: MapPageUrl;
 }
 
 export const Block: React.FC<Block> = props => {
-  const { block, children, listNumber, level } = props;
+  const { block, children, level, fullPage, blockMap } = props;
   const blockValue = block?.value;
   switch (blockValue?.type) {
     case "page":
-      if (level === 0) return <div className="notion">{children}</div>;
-      else {
+      if (level === 0) {
+        if (fullPage) {
+          if (!blockValue.properties) {
+            return null;
+          }
+
+          const {
+            page_icon,
+            page_cover,
+            page_cover_position,
+            page_full_width,
+            page_small_text
+          } = blockValue.format || {};
+
+          return (
+            <div className="notion">
+              {page_cover && (
+                <img
+                  src={toNotionImageUrl(page_cover)}
+                  alt={getTextContent(blockValue.properties.title)}
+                  className="notion-page-cover"
+                  style={{
+                    objectPosition: `center ${
+                      (1 - (page_cover_position || 0.5)) * 100
+                    }%`
+                  }}
+                />
+              )}
+              <div
+                className={classNames(
+                  "notion-page",
+                  !page_cover && "notion-page-offset",
+                  page_full_width && "notion-full-width",
+                  page_small_text && "notion-small-text"
+                )}
+              >
+                {page_icon && (
+                  <PageIcon
+                    className={
+                      page_cover ? "notion-page-icon-offset" : undefined
+                    }
+                    block={block}
+                    big
+                  />
+                )}
+                <div className="notion-title">
+                  {renderChildText(blockValue.properties.title)}
+                </div>
+                {children}
+              </div>
+            </div>
+          );
+        } else {
+          return <div className="notion">{children}</div>;
+        }
+      } else {
         if (!blockValue.properties) return null;
         return (
           <a
@@ -68,7 +135,7 @@ export const Block: React.FC<Block> = props => {
           >
             {blockValue.format && (
               <div className="notion-page-icon">
-                {blockValue.format.page_icon}
+                <PageIcon block={block} />
               </div>
             )}
             <div className="notion-page-text">
@@ -102,10 +169,16 @@ export const Block: React.FC<Block> = props => {
       return <hr className="notion-hr" />;
     case "text":
       if (!blockValue.properties) {
-        return <p style={{ height: "1rem" }}> </p>;
+        return <div className="notion-blank" />;
       }
+      const blockColor = blockValue.format?.block_color;
       return (
-        <p className={`notion-text`}>
+        <p
+          className={classNames(
+            `notion-text`,
+            blockColor && `notion-${blockColor}`
+          )}
+        >
           {renderChildText(blockValue.properties.title)}
         </p>
       );
@@ -137,7 +210,11 @@ export const Block: React.FC<Block> = props => {
         ) : null;
       }
 
-      return listNumber !== undefined ? wrapList(output, listNumber) : output;
+      const isTopLevel =
+        block.value.type !== blockMap[block.value.parent_id].value.type;
+      const start = getListNumber(blockValue.id, blockMap);
+
+      return isTopLevel ? wrapList(output, start) : output;
 
     case "image":
     case "embed":
@@ -199,7 +276,9 @@ export const Block: React.FC<Block> = props => {
               `notion-${blockValue.format.block_color}_co`
           )}
         >
-          <div>{blockValue.format.page_icon}</div>
+          <div>
+            <PageIcon block={block} />
+          </div>
           <div className="notion-callout-text">
             {renderChildText(blockValue.properties.title)}
           </div>

--- a/src/components/asset.tsx
+++ b/src/components/asset.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { BlockType, ContentValueType } from "../types";
+import { toNotionImageUrl } from "../utils";
 
 const types = ["video", "image", "embed"];
 
@@ -34,9 +35,7 @@ const Asset: React.FC<{ block: BlockType }> = ({ block }) => {
     );
   }
 
-  const src = `https://notion.so/image/${encodeURIComponent(
-    value.properties.source[0][0]
-  )}`;
+  const src = toNotionImageUrl(value.properties.source[0][0]);
 
   if (type === "image") {
     const caption = value.properties.caption?.[0][0];

--- a/src/components/code.tsx
+++ b/src/components/code.tsx
@@ -10,9 +10,8 @@ const Code: React.FC<{ code: string; language: string }> = ({
     languages[language.toLowerCase()] || languages.javascript;
 
   return (
-    <pre>
+    <pre className="notion-code">
       <code
-        className="notion-code"
         dangerouslySetInnerHTML={{
           __html: highlight(code, prismLanguage, language)
         }}

--- a/src/components/page-icon.tsx
+++ b/src/components/page-icon.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import {
+  BlockType,
+  PageValueType,
+  BlockValueType,
+  CalloutValueType
+} from "../types";
+import { toNotionImageUrl, getTextContent, classNames } from "../utils";
+
+const isIconBlock = (
+  value: BlockValueType
+): value is PageValueType | CalloutValueType => {
+  return value.type === "page" || value.type === "callout";
+};
+
+interface AssetProps {
+  block: BlockType;
+  big?: boolean;
+  className?: string;
+}
+
+const PageIcon: React.FC<AssetProps> = ({ block, className, big }) => {
+  if (!isIconBlock(block.value)) {
+    return null;
+  }
+  const icon = block.value.format.page_icon;
+  const title = block.value.properties?.title;
+
+  if (icon?.includes("http")) {
+    return (
+      <img
+        className={classNames(
+          className,
+          big ? "notion-page-icon-cover" : "notion-page-icon"
+        )}
+        src={toNotionImageUrl(icon)}
+        alt={title ? getTextContent(title) : "Icon"}
+      />
+    );
+  } else {
+    return (
+      <span
+        className={classNames(
+          className,
+          big ? "notion-page-icon-cover" : "notion-page-icon"
+        )}
+        role="image"
+        aria-label={icon}
+      >
+        {icon}
+      </span>
+    );
+  }
+};
+
+export default PageIcon;

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -2,48 +2,34 @@ import React from "react";
 import { BlockMapType } from "./types";
 import { Block, MapPageUrl } from "./block";
 
-import { getListNumber } from "./utils";
-
 export interface NotionRendererProps {
   blockMap: BlockMapType;
+  mapPageUrl?: MapPageUrl;
+  fullPage?: boolean;
+
   currentId?: string;
   level?: number;
-  mapPageUrl?: MapPageUrl;
 }
 
 export const NotionRenderer: React.FC<NotionRendererProps> = ({
   level = 0,
   currentId,
-  blockMap,
-  mapPageUrl
+  ...props
 }) => {
+  const { blockMap } = props;
   const id = currentId || Object.keys(blockMap)[0];
   const currentBlock = blockMap[id];
-  const parentBlock = blockMap[currentBlock.value.parent_id];
 
   if (!currentBlock) return null;
 
-  const listNumber =
-    currentBlock.value.type === "numbered_list" &&
-    parentBlock.value.type !== "numbered_list"
-      ? getListNumber(id, blockMap)
-      : undefined;
-
   return (
-    <Block
-      key={id}
-      level={level}
-      block={currentBlock}
-      listNumber={listNumber}
-      mapPageUrl={mapPageUrl}
-    >
+    <Block key={id} level={level} block={currentBlock} {...props}>
       {currentBlock?.value?.content?.map(contentId => (
         <NotionRenderer
           key={contentId}
           currentId={contentId}
-          blockMap={blockMap}
           level={level + 1}
-          mapPageUrl={mapPageUrl}
+          {...props}
         />
       ))}
     </Block>

--- a/src/styles.css
+++ b/src/styles.css
@@ -97,41 +97,90 @@
 .notion-gray_background_co {
   background-color: rgb(235, 236, 237, 0.3);
 }
-h1,
-h2,
-h3 {
-  margin-block-start: 0px;
-  margin-block-end: 0px;
-}
-.notion-h1 {
+
+.notion b {
   font-weight: 600;
-  font-size: 1.875em;
-  line-height: 1.3;
-  color: inherit;
-  margin-top: 1.4em;
-  margin-bottom: 1px;
 }
-.notion-h1:first-child {
-  margin-top: 0px;
+
+.notion-title {
+  font-size: 2.5em;
+  font-weight: 700;
+  margin-top: 0.75em;
+  margin-bottom: 0.25em;
 }
-.notion-h2 {
-  font-weight: 600;
-  font-size: 1.5em;
-  line-height: 1.3;
-  color: inherit;
-  fill: inherit;
-  margin-top: 1.1em;
-  margin-bottom: 1px;
-  padding: 3px 2px;
-}
+
+.notion-h1,
+.notion-h2,
 .notion-h3 {
   font-weight: 600;
-  font-size: 1.25em;
   line-height: 1.3;
-  color: inherit;
-  fill: inherit;
+  padding: 3px 2px;
+}
+
+.notion-h1 {
+  font-size: 1.875em;
+  margin-top: 1.4em;
+}
+.notion-h1:first-of-type {
+  margin-top: 0;
+}
+.notion-h2 {
+  font-size: 1.5em;
+  margin-top: 1.1em;
+}
+.notion-h3 {
+  font-size: 1.25em;
   margin-top: 1em;
-  margin-bottom: 1px;
+}
+.notion-page-cover {
+  display: block;
+  object-fit: cover;
+  width: 100%;
+  height: 30vh;
+  padding: 0;
+}
+
+.notion-page {
+  padding: 0 12px;
+  margin: 0 auto;
+  max-width: 704px;
+}
+
+.notion-page-offset {
+  margin-top: 96px;
+}
+
+span.notion-page-icon-cover {
+  height: 78px;
+  width: 78px;
+  font-size: 78px;
+  display: inline-block;
+  line-height: 1.1;
+  margin-left: 0px;
+}
+
+span.notion-page-icon-offset {
+  margin-top: -42px;
+}
+
+img.notion-page-icon-cover {
+  border-radius: 3px;
+  width: 124px;
+  height: 124px;
+  margin: 8px;
+}
+
+img.notion-page-icon-offset {
+  margin-top: -80px;
+}
+
+.notion-full-width {
+  padding: 0 40px;
+  max-width: 100%;
+}
+
+.notion-small-text {
+  font-size: 14px;
 }
 .notion-quote {
   white-space: pre-wrap;
@@ -149,10 +198,14 @@ h3 {
 }
 .notion-link {
   color: inherit;
+  word-break: break-all;
   text-decoration: underline;
   text-decoration-color: inherit;
 }
-
+.notion-blank {
+  height: 1rem;
+  padding: 4px 0;
+}
 .notion-page-link {
   display: flex;
   color: rgb(55, 53, 47);
@@ -166,10 +219,18 @@ h3 {
 }
 
 .notion-page-icon {
-  padding: 0px 5px;
   margin-right: 4px;
   margin-top: 2px;
+  margin-left: 2px;
 }
+img.notion-page-icon {
+  display: block;
+  object-fit: cover;
+  border-radius: 3px;
+  width: 20px;
+  height: 20px;
+}
+
 .notion-page-text {
   white-space: nowrap;
   overflow: hidden;
@@ -223,7 +284,7 @@ h3 {
 }
 
 .notion-asset-wrapper {
-  margin: 2px auto 0.5rem;
+  margin: 2px 0 0.5rem;
   max-width: 100%;
 }
 
@@ -234,6 +295,7 @@ h3 {
 .notion-text {
   white-space: pre-wrap;
   caret-color: rgb(55, 53, 47);
+  padding: 3px 2px;
 }
 .notion-block {
   padding: 3px 2px;
@@ -271,10 +333,13 @@ h3 {
 
 .notion-row {
   display: flex;
+  overflow: hidden;
 }
 
 .notion-bookmark {
   margin: 4px 0;
+  width: 100%;
+  box-sizing: border-box;
   text-decoration: none;
   border: 1px solid rgba(55, 53, 47, 0.16);
   border-radius: 3px;
@@ -387,19 +452,21 @@ h3 {
 
 .notion-callout {
   padding: 16px 16px 16px 12px;
-  display: flex;
+  display: inline-flex;
   width: 100%;
   border-radius: 3px;
   border-width: 1px;
-  border-style: solid;
-  border-color: transparent;
   align-items: center;
   box-sizing: border-box;
+  margin: 4px 0;
 }
 .notion-callout-text {
   margin-left: 8px;
 }
 
+.notion-toggle {
+  padding: 3px 2px;
+}
 .notion-toggle > div {
   margin-left: 1.1em;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,7 +79,7 @@ type BaseDecorationType = [string];
 type AdditionalDecorationType = [string, SubDecorationType[]];
 export type DecorationType = BaseDecorationType | AdditionalDecorationType;
 
-interface PageValueType extends BaseValueType {
+export interface PageValueType extends BaseValueType {
   type: "page";
   properties?: {
     title: DecorationType[];
@@ -171,7 +171,7 @@ interface ColumnValueType extends BaseValueType {
   };
 }
 
-interface CalloutValueType extends BaseValueType {
+export interface CalloutValueType extends BaseValueType {
   type: "callout";
   format: {
     page_icon: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,9 +15,9 @@ const groupBlockContent = (blockMap: BlockMapType): string[][] => {
 
   Object.keys(blockMap).forEach(id => {
     blockMap[id].value.content?.forEach(blockId => {
-      const blockType = blockMap[blockId].value.type;
+      const blockType = blockMap[blockId]?.value.type;
 
-      if (blockType !== lastType) {
+      if (blockType && blockType !== lastType) {
         index++;
         lastType = blockType;
         output[index] = [];
@@ -41,4 +41,10 @@ export const getListNumber = (blockId: string, blockMap: BlockMapType) => {
   }
 
   return group.indexOf(blockId) + 1;
+};
+
+export const toNotionImageUrl = (url: string) => {
+  return `https://notion.so${
+    url.startsWith("/image") ? url : `/image/${encodeURIComponent(url)}`
+  }`;
 };


### PR DESCRIPTION
Full page mode does the following things
- Wraps content with correct page width (full width or regular)
- Applies small font-size
- Adds page cover if available
- Renders page icon + title

Things changed along the way:
- Style improvements throughout
- Allow custom images for icons
- Add support for whole-block styles