### PR TITLE
Expose language via classname

### DIFF
--- a/src/components/code.tsx
+++ b/src/components/code.tsx
@@ -12,6 +12,7 @@ const Code: React.FC<{ code: string; language: string }> = ({
   return (
     <pre className="notion-code">
       <code
+        className={`language-${language.toLowerCase()}`}
         dangerouslySetInnerHTML={{
           __html: highlight(code, prismLanguage, language)
         }}


### PR DESCRIPTION
In order to read the code block language, I need to expose it as a className. My use case is I'm using this in a Gatsby project for Notion as a source for a blog. Thanks for your amazing work on this project by the way!