### PR TITLE
feat: bulk import of improvements made for notion2site

### DIFF
--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -18,12 +14,6 @@
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "exclude": [
-    "node_modules"
-  ],
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ]
+  "exclude": ["node_modules"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
 }

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -14,6 +18,12 @@
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "exclude": ["node_modules"],
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
+  "exclude": [
+    "node_modules"
+  ],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   },
   "dependencies": {
     "medium-zoom": "^1.0.5",
-    "prismjs": "^1.20.0",
-    "react-modal": "^3.11.2"
+    "prismjs": "^1.20.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,16 +46,16 @@
     "react": ">=16"
   },
   "devDependencies": {
-    "@types/prismjs": "^1.16.0",
-    "@types/react": "^16.9.34",
-    "@types/react-dom": "^16.9.6",
+    "@types/prismjs": "^1.16.1",
+    "@types/react": "^16.9.43",
+    "@types/react-dom": "^16.9.8",
     "husky": "^4.2.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "rollup-plugin-copy": "^3.3.0",
     "tsdx": "^0.13.2",
-    "tslib": "^1.11.1",
-    "typescript": "^3.8.3"
+    "tslib": "^2.0.0",
+    "typescript": "^3.9.7"
   },
   "dependencies": {
     "medium-zoom": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "typescript": "^3.9.7"
   },
   "dependencies": {
-    "medium-zoom": "^1.0.5",
     "prismjs": "^1.20.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "prismjs": "^1.20.0"
+    "medium-zoom": "^1.0.5",
+    "prismjs": "^1.20.0",
+    "react-modal": "^3.11.2"
   }
 }

--- a/src/block.tsx
+++ b/src/block.tsx
@@ -61,7 +61,6 @@ interface Block {
   mapImageUrl: MapImageUrl;
 
   fullPage?: boolean;
-  zoom?: any;
 }
 
 export const Block: React.FC<Block> = props => {
@@ -71,7 +70,6 @@ export const Block: React.FC<Block> = props => {
     level,
     fullPage,
     blockMap,
-    zoom,
     mapPageUrl,
     mapImageUrl
   } = props;
@@ -246,7 +244,7 @@ export const Block: React.FC<Block> = props => {
           className="notion-asset-wrapper"
           style={{ width: value.format.block_width }}
         >
-          <Asset block={block} zoom={zoom} mapImageUrl={mapImageUrl} />
+          <Asset block={block} mapImageUrl={mapImageUrl} />
 
           {value.properties.caption && (
             <figcaption className="notion-image-caption">

--- a/src/block.tsx
+++ b/src/block.tsx
@@ -4,18 +4,14 @@ import {
   BlockType,
   ContentValueType,
   BlockMapType,
-  MapPageUrl
+  MapPageUrl,
+  MapImageUrl
 } from "./types";
 import Asset from "./components/asset";
 import Code from "./components/code";
 import PageIcon from "./components/page-icon";
 import PageHeader from "./components/page-header";
-import {
-  classNames,
-  getTextContent,
-  getListNumber,
-  toNotionImageUrl
-} from "./utils";
+import { classNames, getTextContent, getListNumber } from "./utils";
 
 export const renderChildText = (properties: DecorationType[]) => {
   return properties?.map(([text, decorations], i) => {
@@ -62,6 +58,7 @@ interface Block {
   level: number;
   blockMap: BlockMapType;
   mapPageUrl: MapPageUrl;
+  mapImageUrl: MapImageUrl;
 
   fullPage?: boolean;
   zoom?: any;
@@ -75,7 +72,8 @@ export const Block: React.FC<Block> = props => {
     fullPage,
     blockMap,
     zoom,
-    mapPageUrl
+    mapPageUrl,
+    mapImageUrl
   } = props;
   const blockValue = block?.value;
 
@@ -101,12 +99,16 @@ export const Block: React.FC<Block> = props => {
             <div className="notion notion-app">
               <div className="notion-cursor-listener">
                 <div className="notion-frame">
-                  <PageHeader blockMap={blockMap} mapPageUrl={mapPageUrl} />
+                  <PageHeader
+                    blockMap={blockMap}
+                    mapPageUrl={mapPageUrl}
+                    mapImageUrl={mapImageUrl}
+                  />
 
                   <div className="notion-scroller">
                     {page_cover && (
                       <img
-                        src={toNotionImageUrl(page_cover)}
+                        src={mapImageUrl(page_cover)}
                         alt={getTextContent(blockValue.properties.title)}
                         className="notion-page-cover"
                         style={{
@@ -129,6 +131,7 @@ export const Block: React.FC<Block> = props => {
                           }
                           block={block}
                           big
+                          mapImageUrl={mapImageUrl}
                         />
                       )}
 
@@ -152,7 +155,7 @@ export const Block: React.FC<Block> = props => {
           <a className="notion-page-link" href={mapPageUrl(blockValue.id)}>
             {blockValue.format && (
               <div className="notion-page-icon">
-                <PageIcon block={block} />
+                <PageIcon block={block} mapImageUrl={mapImageUrl} />
               </div>
             )}
             <div className="notion-page-text">
@@ -243,7 +246,7 @@ export const Block: React.FC<Block> = props => {
           className="notion-asset-wrapper"
           style={{ width: value.format.block_width }}
         >
-          <Asset block={block} zoom={zoom} />
+          <Asset block={block} zoom={zoom} mapImageUrl={mapImageUrl} />
 
           {value.properties.caption && (
             <figcaption className="notion-image-caption">
@@ -373,7 +376,7 @@ export const Block: React.FC<Block> = props => {
           )}
         >
           <div>
-            <PageIcon block={block} />
+            <PageIcon block={block} mapImageUrl={mapImageUrl} />
           </div>
           <div className="notion-callout-text">
             {renderChildText(blockValue.properties.title)}

--- a/src/block.tsx
+++ b/src/block.tsx
@@ -61,6 +61,7 @@ interface Block {
   mapImageUrl: MapImageUrl;
 
   fullPage?: boolean;
+  hideHeader?: boolean;
 }
 
 export const Block: React.FC<Block> = props => {
@@ -69,6 +70,7 @@ export const Block: React.FC<Block> = props => {
     children,
     level,
     fullPage,
+    hideHeader,
     blockMap,
     mapPageUrl,
     mapImageUrl
@@ -97,11 +99,13 @@ export const Block: React.FC<Block> = props => {
             <div className="notion notion-app">
               <div className="notion-cursor-listener">
                 <div className="notion-frame">
-                  <PageHeader
-                    blockMap={blockMap}
-                    mapPageUrl={mapPageUrl}
-                    mapImageUrl={mapImageUrl}
-                  />
+                  {!hideHeader && (
+                    <PageHeader
+                      blockMap={blockMap}
+                      mapPageUrl={mapPageUrl}
+                      mapImageUrl={mapImageUrl}
+                    />
+                  )}
 
                   <div className="notion-scroller">
                     {page_cover && (

--- a/src/components/asset.tsx
+++ b/src/components/asset.tsx
@@ -6,9 +6,7 @@ const types = ["video", "image", "embed"];
 const Asset: React.FC<{
   block: BlockType;
   mapImageUrl: MapImageUrl;
-  zoom?: any;
-}> = ({ block, mapImageUrl, zoom }) => {
-  const zoomRef = React.useRef(zoom ? zoom.clone() : null);
+}> = ({ block, mapImageUrl }) => {
   const value = block.value as ContentValueType;
   const type = block.value.type;
 
@@ -41,12 +39,6 @@ const Asset: React.FC<{
 
   const src = mapImageUrl(value.properties.source[0][0]);
 
-  function attachZoom(image: any) {
-    if (zoomRef.current) {
-      (zoomRef.current as any).attach(image);
-    }
-  }
-
   if (type === "image") {
     const caption = value.properties.caption?.[0][0];
 
@@ -62,12 +54,11 @@ const Asset: React.FC<{
             className="notion-image-inset"
             alt={caption || "notion image"}
             src={src}
-            ref={attachZoom}
           />
         </div>
       );
     } else {
-      return <img alt={caption} src={src} ref={attachZoom} />;
+      return <img alt={caption} src={src} />;
     }
   }
 

--- a/src/components/asset.tsx
+++ b/src/components/asset.tsx
@@ -4,7 +4,8 @@ import { toNotionImageUrl } from "../utils";
 
 const types = ["video", "image", "embed"];
 
-const Asset: React.FC<{ block: BlockType }> = ({ block }) => {
+const Asset: React.FC<{ block: BlockType; zoom?: any }> = ({ block, zoom }) => {
+  const zoomRef = React.useRef(zoom ? zoom.clone() : null);
   const value = block.value as ContentValueType;
   const type = block.value.type;
 
@@ -37,8 +38,15 @@ const Asset: React.FC<{ block: BlockType }> = ({ block }) => {
 
   const src = toNotionImageUrl(value.properties.source[0][0]);
 
+  function attachZoom(image: any) {
+    if (zoomRef.current) {
+      (zoomRef.current as any).attach(image);
+    }
+  }
+
   if (type === "image") {
     const caption = value.properties.caption?.[0][0];
+
     if (block_aspect_ratio) {
       return (
         <div
@@ -47,11 +55,16 @@ const Asset: React.FC<{ block: BlockType }> = ({ block }) => {
             position: "relative"
           }}
         >
-          <img className="notion-image-inset" alt={caption} src={src} />
+          <img
+            className="notion-image-inset"
+            alt={caption || "notion image"}
+            src={src}
+            ref={attachZoom}
+          />
         </div>
       );
     } else {
-      return <img alt={caption} src={src} />;
+      return <img alt={caption} src={src} ref={attachZoom} />;
     }
   }
 

--- a/src/components/asset.tsx
+++ b/src/components/asset.tsx
@@ -1,10 +1,13 @@
 import * as React from "react";
-import { BlockType, ContentValueType } from "../types";
-import { toNotionImageUrl } from "../utils";
+import { BlockType, ContentValueType, MapImageUrl } from "../types";
 
 const types = ["video", "image", "embed"];
 
-const Asset: React.FC<{ block: BlockType; zoom?: any }> = ({ block, zoom }) => {
+const Asset: React.FC<{
+  block: BlockType;
+  mapImageUrl: MapImageUrl;
+  zoom?: any;
+}> = ({ block, mapImageUrl, zoom }) => {
   const zoomRef = React.useRef(zoom ? zoom.clone() : null);
   const value = block.value as ContentValueType;
   const type = block.value.type;
@@ -36,7 +39,7 @@ const Asset: React.FC<{ block: BlockType; zoom?: any }> = ({ block, zoom }) => {
     );
   }
 
-  const src = toNotionImageUrl(value.properties.source[0][0]);
+  const src = mapImageUrl(value.properties.source[0][0]);
 
   function attachZoom(image: any) {
     if (zoomRef.current) {

--- a/src/components/code.tsx
+++ b/src/components/code.tsx
@@ -6,8 +6,8 @@ const Code: React.FC<{ code: string; language: string }> = ({
   code,
   language = "javascript"
 }) => {
-  const prismLanguage =
-    languages[language.toLowerCase()] || languages.javascript;
+  const languageL = language.toLowerCase();
+  const prismLanguage = languages[languageL] || languages.javascript;
 
   const langClass = `language-${language.toLowerCase()}`;
 

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -1,0 +1,91 @@
+import * as React from "react";
+
+import { BlockMapType, MapPageUrl } from "../types";
+import PageIcon from "./page-icon";
+
+interface PageHeaderProps {
+  blockMap: BlockMapType;
+  mapPageUrl: MapPageUrl;
+}
+
+const PageHeader: React.FC<PageHeaderProps> = ({ blockMap, mapPageUrl }) => {
+  const blockIds = Object.keys(blockMap);
+  const activePageId = blockIds[0];
+
+  if (!activePageId) {
+    return null;
+  }
+
+  const breadcrumbs = [];
+  let currentPageId = activePageId;
+
+  do {
+    const block = blockMap[currentPageId];
+    if (!block || !block.value) {
+      break;
+    }
+
+    const title = block.value.properties?.title[0][0];
+    const icon = (block.value as any).format?.page_icon;
+
+    if (!(title || icon)) {
+      break;
+    }
+
+    breadcrumbs.push({
+      block,
+      active: currentPageId === activePageId,
+      pageId: currentPageId,
+      title,
+      icon
+    });
+
+    const parentId = block.value.parent_id;
+
+    if (!parentId) {
+      break;
+    }
+
+    currentPageId = parentId;
+  } while (true);
+
+  breadcrumbs.reverse();
+
+  return (
+    <header className="notion-page-header">
+      <div className="notion-nav-header">
+        <div className="notion-nav-breadcrumbs">
+          {breadcrumbs.map((breadcrumb, index) => (
+            <React.Fragment key={breadcrumb.pageId}>
+              <a
+                className={`notion-nav-breadcrumb ${
+                  breadcrumb.active ? "notion-nav-breadcrumb-active" : ""
+                }`}
+                href={
+                  breadcrumb.active ? undefined : mapPageUrl(breadcrumb.pageId)
+                }
+              >
+                {breadcrumb.icon && (
+                  <PageIcon
+                    className="notion-nav-icon"
+                    block={breadcrumb.block}
+                  />
+                )}
+
+                {breadcrumb.title && (
+                  <span className="notion-nav-title">{breadcrumb.title}</span>
+                )}
+              </a>
+
+              {index < breadcrumbs.length - 1 && (
+                <span className="notion-nav-spacer">/</span>
+              )}
+            </React.Fragment>
+          ))}
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default PageHeader;

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -1,14 +1,19 @@
 import * as React from "react";
 
-import { BlockMapType, MapPageUrl } from "../types";
+import { BlockMapType, MapPageUrl, MapImageUrl } from "../types";
 import PageIcon from "./page-icon";
 
 interface PageHeaderProps {
   blockMap: BlockMapType;
   mapPageUrl: MapPageUrl;
+  mapImageUrl: MapImageUrl;
 }
 
-const PageHeader: React.FC<PageHeaderProps> = ({ blockMap, mapPageUrl }) => {
+const PageHeader: React.FC<PageHeaderProps> = ({
+  blockMap,
+  mapPageUrl,
+  mapImageUrl
+}) => {
   const blockIds = Object.keys(blockMap);
   const activePageId = blockIds[0];
 
@@ -69,6 +74,7 @@ const PageHeader: React.FC<PageHeaderProps> = ({ blockMap, mapPageUrl }) => {
                   <PageIcon
                     className="notion-nav-icon"
                     block={breadcrumb.block}
+                    mapImageUrl={mapImageUrl}
                   />
                 )}
 

--- a/src/components/page-icon.tsx
+++ b/src/components/page-icon.tsx
@@ -3,9 +3,10 @@ import {
   BlockType,
   PageValueType,
   BlockValueType,
-  CalloutValueType
+  CalloutValueType,
+  MapImageUrl
 } from "../types";
-import { toNotionImageUrl, getTextContent, classNames } from "../utils";
+import { getTextContent, classNames } from "../utils";
 
 const isIconBlock = (
   value: BlockValueType
@@ -15,11 +16,17 @@ const isIconBlock = (
 
 interface AssetProps {
   block: BlockType;
+  mapImageUrl: MapImageUrl;
   big?: boolean;
   className?: string;
 }
 
-const PageIcon: React.FC<AssetProps> = ({ block, className, big }) => {
+const PageIcon: React.FC<AssetProps> = ({
+  block,
+  className,
+  big,
+  mapImageUrl
+}) => {
   if (!isIconBlock(block.value)) {
     return null;
   }
@@ -27,7 +34,7 @@ const PageIcon: React.FC<AssetProps> = ({ block, className, big }) => {
   const title = block.value.properties?.title;
 
   if (icon?.includes("http")) {
-    const url = toNotionImageUrl(icon);
+    const url = mapImageUrl(icon);
 
     return (
       <img

--- a/src/components/page-icon.tsx
+++ b/src/components/page-icon.tsx
@@ -23,17 +23,19 @@ const PageIcon: React.FC<AssetProps> = ({ block, className, big }) => {
   if (!isIconBlock(block.value)) {
     return null;
   }
-  const icon = block.value.format.page_icon;
+  const icon = block.value.format?.page_icon;
   const title = block.value.properties?.title;
 
   if (icon?.includes("http")) {
+    const url = toNotionImageUrl(icon);
+
     return (
       <img
         className={classNames(
           className,
           big ? "notion-page-icon-cover" : "notion-page-icon"
         )}
-        src={toNotionImageUrl(icon)}
+        src={url}
         alt={title ? getTextContent(title) : "Icon"}
       />
     );
@@ -44,7 +46,7 @@ const PageIcon: React.FC<AssetProps> = ({ block, className, big }) => {
           className,
           big ? "notion-page-icon-cover" : "notion-page-icon"
         )}
-        role="image"
+        role="img"
         aria-label={icon}
       >
         {icon}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,3 @@
 export { NotionRenderer } from "./renderer";
 export * from "./types";
+export * from "./utils";

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import mediumZoom from "medium-zoom";
 import { BlockMapType, MapPageUrl, MapImageUrl } from "./types";
 import { Block } from "./block";
-import { defaultMapImageUrl, defaultMapPageUrl } from "utils";
+import { defaultMapImageUrl, defaultMapPageUrl } from "./utils";
 
 export interface NotionRendererProps {
   blockMap: BlockMapType;
@@ -12,7 +11,6 @@ export interface NotionRendererProps {
 
   currentId?: string;
   level?: number;
-  zoom?: any;
 }
 
 export const NotionRenderer: React.FC<NotionRendererProps> = ({
@@ -33,21 +31,11 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
     return null;
   }
 
-  const zoom =
-    props.zoom ||
-    (typeof window !== "undefined" &&
-      mediumZoom({
-        container: ".notion",
-        background: "rgba(0, 0, 0, 0.8)",
-        margin: getMediumZoomMargin()
-      }));
-
   return (
     <Block
       key={id}
       level={level}
       block={currentBlock}
-      zoom={zoom}
       mapPageUrl={mapPageUrl}
       mapImageUrl={mapImageUrl}
       {...props}
@@ -57,7 +45,6 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
           key={contentId}
           currentId={contentId}
           level={level + 1}
-          zoom={zoom}
           mapPageUrl={mapPageUrl}
           mapImageUrl={mapImageUrl}
           {...props}
@@ -66,21 +53,3 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
     </Block>
   );
 };
-
-function getMediumZoomMargin() {
-  const width = window.innerWidth;
-
-  if (width < 500) {
-    return 8;
-  } else if (width < 800) {
-    return 20;
-  } else if (width < 1280) {
-    return 30;
-  } else if (width < 1600) {
-    return 40;
-  } else if (width < 1920) {
-    return 48;
-  } else {
-    return 72;
-  }
-}

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -1,15 +1,28 @@
 import React from "react";
-import { BlockMapType } from "./types";
-import { Block, MapPageUrl } from "./block";
+import mediumZoom from "medium-zoom";
+import { BlockMapType, MapPageUrl } from "./types";
+import { Block } from "./block";
 
 export interface NotionRendererProps {
   blockMap: BlockMapType;
-  mapPageUrl?: MapPageUrl;
   fullPage?: boolean;
+  mapPageUrl?: MapPageUrl;
+  rootPageId?: string;
 
   currentId?: string;
   level?: number;
+  zoom?: any;
 }
+
+const defaultMapPageUrl = (rootPageId?: string) => (pageId = "") => {
+  pageId = pageId.replace(/-/g, "");
+
+  if (rootPageId && pageId === rootPageId) {
+    return "/";
+  } else {
+    return `/${pageId}`;
+  }
+};
 
 export const NotionRenderer: React.FC<NotionRendererProps> = ({
   level = 0,
@@ -20,18 +33,60 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
   const id = currentId || Object.keys(blockMap)[0];
   const currentBlock = blockMap[id];
 
-  if (!currentBlock) return null;
+  if (!currentBlock) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("error rendering block", currentId);
+    }
+    return null;
+  }
+
+  const mapPageUrl = props.mapPageUrl || defaultMapPageUrl(props.rootPageId);
+  const zoom =
+    props.zoom ||
+    (typeof window !== "undefined" &&
+      mediumZoom({
+        container: ".notion",
+        background: "rgba(0, 0, 0, 0.8)",
+        margin: getMediumZoomMargin()
+      }));
 
   return (
-    <Block key={id} level={level} block={currentBlock} {...props}>
+    <Block
+      key={id}
+      level={level}
+      block={currentBlock}
+      zoom={zoom}
+      mapPageUrl={mapPageUrl}
+      {...props}
+    >
       {currentBlock?.value?.content?.map(contentId => (
         <NotionRenderer
           key={contentId}
           currentId={contentId}
           level={level + 1}
+          zoom={zoom}
+          mapPageUrl={mapPageUrl}
           {...props}
         />
       ))}
     </Block>
   );
 };
+
+function getMediumZoomMargin() {
+  const width = window.innerWidth;
+
+  if (width < 500) {
+    return 8;
+  } else if (width < 800) {
+    return 20;
+  } else if (width < 1280) {
+    return 30;
+  } else if (width < 1600) {
+    return 40;
+  } else if (width < 1920) {
+    return 48;
+  } else {
+    return 72;
+  }
+}

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -6,6 +6,7 @@ import { defaultMapImageUrl, defaultMapPageUrl } from "./utils";
 export interface NotionRendererProps {
   blockMap: BlockMapType;
   fullPage?: boolean;
+  hideHeader?: boolean;
   mapPageUrl?: MapPageUrl;
   mapImageUrl?: MapImageUrl;
 

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -1,32 +1,25 @@
 import React from "react";
 import mediumZoom from "medium-zoom";
-import { BlockMapType, MapPageUrl } from "./types";
+import { BlockMapType, MapPageUrl, MapImageUrl } from "./types";
 import { Block } from "./block";
+import { defaultMapImageUrl, defaultMapPageUrl } from "utils";
 
 export interface NotionRendererProps {
   blockMap: BlockMapType;
   fullPage?: boolean;
   mapPageUrl?: MapPageUrl;
-  rootPageId?: string;
+  mapImageUrl?: MapImageUrl;
 
   currentId?: string;
   level?: number;
   zoom?: any;
 }
 
-const defaultMapPageUrl = (rootPageId?: string) => (pageId = "") => {
-  pageId = pageId.replace(/-/g, "");
-
-  if (rootPageId && pageId === rootPageId) {
-    return "/";
-  } else {
-    return `/${pageId}`;
-  }
-};
-
 export const NotionRenderer: React.FC<NotionRendererProps> = ({
   level = 0,
   currentId,
+  mapPageUrl = defaultMapPageUrl,
+  mapImageUrl = defaultMapImageUrl,
   ...props
 }) => {
   const { blockMap } = props;
@@ -40,7 +33,6 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
     return null;
   }
 
-  const mapPageUrl = props.mapPageUrl || defaultMapPageUrl(props.rootPageId);
   const zoom =
     props.zoom ||
     (typeof window !== "undefined" &&
@@ -57,6 +49,7 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
       block={currentBlock}
       zoom={zoom}
       mapPageUrl={mapPageUrl}
+      mapImageUrl={mapImageUrl}
       {...props}
     >
       {currentBlock?.value?.content?.map(contentId => (
@@ -66,6 +59,7 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
           level={level + 1}
           zoom={zoom}
           mapPageUrl={mapPageUrl}
+          mapImageUrl={mapImageUrl}
           {...props}
         />
       ))}

--- a/src/styles.css
+++ b/src/styles.css
@@ -185,6 +185,7 @@
   object-fit: cover;
   width: 100%;
   height: 30vh;
+  min-height: 30vh;
   padding: 0;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -16,6 +16,54 @@
   margin-block-end: 0px;
 }
 
+.notion-app {
+  height: 100vh;
+  overflow: hidden;
+  position: relative;
+  background: #fff;
+}
+
+.notion-cursor-listener {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: flex;
+  flex: 1 1 0%;
+  background: #fff;
+}
+
+.medium-zoom-overlay {
+  z-index: 100;
+}
+
+.medium-zoom-image {
+  border-radius: 0;
+  z-index: 101;
+}
+
+.notion-frame {
+  flex-grow: 1;
+  flex-shrink: 1;
+  display: flex;
+  flex-direction: column;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  max-height: 100%;
+}
+
+.notion-scroller {
+  display: flex;
+  flex-direction: column;
+  z-index: 1;
+  flex-grow: 1;
+  position: relative;
+  align-items: center;
+  overflow: auto;
+  margin-right: 0;
+  margin-bottom: 0;
+}
+
 .notion-red {
   color: rgb(224, 62, 62);
 }
@@ -121,6 +169,9 @@
   font-size: 1.875em;
   margin-top: 1.4em;
 }
+.notion-h1:first-child {
+  margin-top: 0;
+}
 .notion-h2 {
   font-size: 1.5em;
   margin-top: 1.1em;
@@ -138,9 +189,16 @@
 }
 
 .notion-page {
-  padding: 0 12px;
+  padding: 0;
   margin: 0 auto;
-  max-width: 704px;
+  max-width: 708px;
+  width: 100%;
+}
+
+@media only screen and (max-width: 730px) {
+  .notion-page {
+    padding: 0 2vw;
+  }
 }
 
 .notion-page-offset {
@@ -195,13 +253,15 @@ img.notion-page-icon-offset {
 }
 .notion-link {
   color: inherit;
-  word-break: break-all;
+  word-break: break-word;
   text-decoration: underline;
   text-decoration-color: inherit;
 }
 .notion-blank {
-  height: 1rem;
-  padding: 4px 0;
+  min-height: 1rem;
+  padding: 3px 2px;
+  margin-top: 1px;
+  margin-bottom: 1px;
 }
 .notion-page-link {
   display: flex;
@@ -216,6 +276,7 @@ img.notion-page-icon-offset {
 }
 
 .notion-page-icon {
+  font-size: 1.1em;
   margin-right: 4px;
   margin-top: 2px;
   margin-left: 2px;
@@ -226,6 +287,13 @@ img.notion-page-icon {
   border-radius: 3px;
   width: 20px;
   height: 20px;
+}
+
+.notion-icon {
+  display: block;
+  width: 18px;
+  height: 18px;
+  color: rgba(55, 53, 47, 0.4);
 }
 
 .notion-page-text {
@@ -281,7 +349,7 @@ img.notion-page-icon {
 }
 
 .notion-asset-wrapper {
-  margin: 2px 0 0.5rem;
+  margin: 0.5rem auto 0.5rem;
   max-width: 100%;
 }
 
@@ -298,17 +366,21 @@ img.notion-page-icon {
   padding: 3px 2px;
 }
 
+.notion .notion-code {
+  font-size: 85%;
+}
+
 .notion-code {
   padding: 30px 16px 30px 20px;
   margin: 4px 0;
+  border-radius: 3px;
   tab-size: 2;
-  font-size: 85%;
   display: block;
+  box-sizing: border-box;
+  overflow-x: scroll;
   background: rgb(247, 246, 243);
   font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, Courier,
     monospace;
-  box-sizing: border-box;
-  overflow-x: scroll;
 }
 
 .notion-column {
@@ -435,6 +507,7 @@ img.notion-page-icon {
   bottom: 0;
   width: 100%;
   height: 100%;
+  border-radius: 1px;
 }
 
 .notion-image-caption {
@@ -463,6 +536,10 @@ img.notion-page-icon {
 
 .notion-toggle {
   padding: 3px 2px;
+}
+.notion-toggle > summary {
+  cursor: pointer;
+  outline: none;
 }
 .notion-toggle > div {
   margin-left: 1.1em;
@@ -551,4 +628,88 @@ img.notion-page-icon {
   font-weight: 500;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.notion-page-header {
+  position: relative;
+  width: 100%;
+  max-width: 100vw;
+  height: 45px;
+  min-height: 45px;
+  z-index: 9;
+}
+
+.notion-nav-header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 100%;
+  display: flex;
+  background: #fff;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 12px;
+  text-size-adjust: 100%;
+  line-height: 1.5;
+  line-height: 1.2;
+  font-size: 14px;
+}
+
+.notion-nav-breadcrumbs {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  height: 100%;
+  flex-grow: 0;
+  min-width: 0;
+  margin-right: 8px;
+}
+
+.notion-nav-breadcrumb {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+
+  color: rgb(55, 53, 47);
+  text-decoration: none;
+  margin: 1px 0px;
+  padding: 4px 6px;
+  border-radius: 3px;
+  transition: background 120ms ease-in 0s;
+  user-select: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+img.notion-nav-icon {
+  width: 18px !important;
+  height: 18px !important;
+}
+
+.notion-nav-icon {
+  font-size: 18px;
+  margin-right: 6px;
+  line-height: 1.1;
+  color: #000;
+}
+
+.notion-nav-breadcrumb:not(.notion-nav-breadcrumb-active):hover {
+  background: rgba(55, 53, 47, 0.08);
+}
+
+.notion-nav-breadcrumb:not(.notion-nav-breadcrumb-active):active {
+  background: rgba(55, 53, 47, 0.16);
+}
+
+.notion-nav-breadcrumb.notion-nav-breadcrumb-active {
+  cursor: default;
+}
+
+.notion-nav-spacer {
+  margin: 0 2px;
+  color: rgba(55, 53, 47, 0.4);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ interface BaseValueType {
   created_by_id: string;
   last_edited_by_table: string;
   last_edited_by_id: string;
+  space_id?: string;
+  properties?: any;
   content?: string[];
 }
 
@@ -318,3 +320,5 @@ export interface LoadPageChunkData {
     stack: any[];
   };
 }
+
+export type MapPageUrl = (pageId: string) => string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -322,3 +322,4 @@ export interface LoadPageChunkData {
 }
 
 export type MapPageUrl = (pageId: string) => string;
+export type MapImageUrl = (image: string) => string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,7 +44,10 @@ export const getListNumber = (blockId: string, blockMap: BlockMapType) => {
 };
 
 export const toNotionImageUrl = (url: string) => {
-  return `https://notion.so${
+  const notionImageUrl = `https://www.notion.so${
     url.startsWith("/image") ? url : `/image/${encodeURIComponent(url)}`
   }`;
+
+  // Our proxy uses Cloudflare's global CDN to cache these image assets
+  return `https://ssfy.io/${encodeURIComponent(notionImageUrl)}`;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,7 @@ const groupBlockContent = (blockMap: BlockMapType): string[][] => {
 
   Object.keys(blockMap).forEach(id => {
     blockMap[id].value.content?.forEach(blockId => {
-      const blockType = blockMap[blockId]?.value.type;
+      const blockType = blockMap[blockId]?.value?.type;
 
       if (blockType && blockType !== lastType) {
         index++;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,11 +43,14 @@ export const getListNumber = (blockId: string, blockMap: BlockMapType) => {
   return group.indexOf(blockId) + 1;
 };
 
-export const toNotionImageUrl = (url: string) => {
-  const notionImageUrl = `https://www.notion.so${
-    url.startsWith("/image") ? url : `/image/${encodeURIComponent(url)}`
+export const defaultMapImageUrl = (image: string = "") => {
+  return `https://www.notion.so${
+    image.startsWith("/image") ? image : `/image/${encodeURIComponent(image)}`
   }`;
+};
 
-  // Our proxy uses Cloudflare's global CDN to cache these image assets
-  return `https://ssfy.io/${encodeURIComponent(notionImageUrl)}`;
+export const defaultMapPageUrl = (pageId: string = "") => {
+  pageId = pageId.replace(/-/g, "");
+
+  return `/${pageId}`;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1135,27 +1135,35 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/prismjs@^1.16.0":
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.16.0.tgz#4328c9f65698e59f4feade8f4e5d928c748fd643"
-  integrity sha512-mEyuziLrfDCQ4juQP1k706BUU/c8OGn/ZFl69AXXY6dStHClKX4P+N8+rhqpul1vRDA2VOygzMRSJJZHyDEOfw==
+"@types/prismjs@^1.16.1":
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.16.1.tgz#50b82947207847db6abcbcd14caa89e3b897c259"
+  integrity sha512-RNgcK3FEc1GpeOkamGDq42EYkb6yZW5OWQwTS56NJIB8WL0QGISQglA7En7NUx9RGP8AC52DOe+squqbAckXlA==
 
 "@types/prop-types@*":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react-dom@^16.9.6":
-  version "16.9.6"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.6.tgz#9e7f83d90566521cc2083be2277c6712dcaf754c"
-  integrity sha512-S6ihtlPMDotrlCJE9ST1fRmYrQNNwfgL61UB4I1W7M6kPulUKx9fXAleW5zpdIjUQ4fTaaog8uERezjsGUj9HQ==
+"@types/react-dom@^16.9.8":
+  version "16.9.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
+  integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.34":
+"@types/react@*":
   version "16.9.34"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.34.tgz#f7d5e331c468f53affed17a8a4d488cd44ea9349"
   integrity sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/react@^16.9.43":
+  version "16.9.43"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.43.tgz#c287f23f6189666ee3bebc2eb8d0f84bcb6cdb6b"
+  integrity sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -5889,10 +5897,15 @@ tslib@1.10.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
-tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
+
+tslib@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
+  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
 
 tsutils@^3.17.1:
   version "3.17.1"
@@ -5930,10 +5943,15 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@^3.7.3, typescript@^3.8.3:
+typescript@^3.7.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+
+typescript@^3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2529,6 +2529,11 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exenv@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -4104,6 +4109,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+medium-zoom@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/medium-zoom/-/medium-zoom-1.0.5.tgz#81413dda20ccdd857141ff420cfab788dd32e20e"
+  integrity sha512-aLGa6WlTuFKWvH88bqTrY5ztJMN+D0hd8UX6BYc4YSoPayppzETjZUcdVcksgaoQEMg4cZSmXPg846fTp2rjRQ==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -4762,7 +4772,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -4808,6 +4818,21 @@ react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-lifecycles-compat@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-modal@^3.11.2:
+  version "3.11.2"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.11.2.tgz#bad911976d4add31aa30dba8a41d11e21c4ac8a4"
+  integrity sha512-o8gvvCOFaG1T7W6JUvsYjRjMVToLZgLIsi5kdhFIQCtHxDkA47LznX62j+l6YQkpXDbvQegsDyxe/+JJsFQN7w==
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.5.10"
+    react-lifecycles-compat "^3.0.0"
+    warning "^4.0.3"
 
 react@^16.13.1:
   version "16.13.1"
@@ -6055,6 +6080,13 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
+
+warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 wcwidth@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2529,11 +2529,6 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-exenv@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
-  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
-
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -4772,7 +4767,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
-prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -4818,21 +4813,6 @@ react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-lifecycles-compat@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
-  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-
-react-modal@^3.11.2:
-  version "3.11.2"
-  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.11.2.tgz#bad911976d4add31aa30dba8a41d11e21c4ac8a4"
-  integrity sha512-o8gvvCOFaG1T7W6JUvsYjRjMVToLZgLIsi5kdhFIQCtHxDkA47LznX62j+l6YQkpXDbvQegsDyxe/+JJsFQN7w==
-  dependencies:
-    exenv "^1.2.0"
-    prop-types "^15.5.10"
-    react-lifecycles-compat "^3.0.0"
-    warning "^4.0.3"
 
 react@^16.13.1:
   version "16.13.1"
@@ -6080,13 +6060,6 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
-
-warning@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
-  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
-  dependencies:
-    loose-envify "^1.0.0"
 
 wcwidth@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4112,11 +4112,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-medium-zoom@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/medium-zoom/-/medium-zoom-1.0.5.tgz#81413dda20ccdd857141ff420cfab788dd32e20e"
-  integrity sha512-aLGa6WlTuFKWvH88bqTrY5ztJMN+D0hd8UX6BYc4YSoPayppzETjZUcdVcksgaoQEMg4cZSmXPg846fTp2rjRQ==
-
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"


### PR DESCRIPTION
This is a large set of improvements that I've come across during the development of [notion2site.com](https://notion2site.com).

Summary of changes:
- added the ability to zoom images via [medium-zoom](https://github.com/francoischalifour/medium-zoom) which matches notion's behavior (and is really slick 😄)
- added breadcrumb navigation to page header in `fullPage` mode
- added a default `mapPageUrl` which more closely resembles notion's behavior
- added the ability to override image urls via `mapImageUrl`
  - I'm using this in notion2site, for instance, to proxy all notion images through a CDN
- in `fullPage` mode, the scrollable area should not include the header to match notion behavior
- **lots of small style fixes**

I removed notion2site's Search box from the header so we can consider that in a different PR.

As discussed on our call, take a look through this set of changes and let's decide the best path forward. I believe this PR should be considered with some small changes as opposed to trying to break things apart at this point, with future PRs being much more focused.

[![](https://storage.googleapis.com/saasify-assets/notion2site-v2.jpg)](https://notion2site.com)