### PR TITLE
fix BookmarkValueType

### DIFF
--- a/src/block.tsx
+++ b/src/block.tsx
@@ -285,6 +285,13 @@ export const Block: React.FC<Block> = props => {
         </div>
       );
     case "bookmark":
+      const link = blockValue.properties.link
+      const title = blockValue.properties.title ?? link
+      const description = blockValue.properties.description
+      const block_color = blockValue.format?.block_color
+      const bookmark_icon = blockValue.format?.bookmark_icon
+      const bookmark_cover = blockValue.format?.bookmark_cover
+          
       return (
         <div className="notion-row">
           <a
@@ -292,32 +299,39 @@ export const Block: React.FC<Block> = props => {
             rel="noopener noreferrer"
             className={classNames(
               "notion-bookmark",
-              blockValue.format.block_color &&
-                `notion-${blockValue.format.block_color}`
+              block_color &&
+                `notion-${block_color}`
             )}
-            href={blockValue.properties.link[0][0]}
+            href={link[0][0]}
           >
             <div>
               <div className="notion-bookmark-title">
-                {renderChildText(blockValue.properties.title)}
+                {renderChildText(title)}
               </div>
-              <div className="notion-bookmark-description">
-                {renderChildText(blockValue.properties.description)}
-              </div>
+              {description && (
+                <div className="notion-bookmark-description">
+                  {renderChildText(description)}
+                </div>
+              )}
+              
               <div className="notion-bookmark-link">
-                <img
-                  src={blockValue.format.bookmark_icon}
-                  alt={getTextContent(blockValue.properties.title)}
-                />
-                <div>{renderChildText(blockValue.properties.link)}</div>
+                {bookmark_icon && (
+                  <img
+                  src={bookmark_icon}
+                  alt={getTextContent(title)}
+                  />
+                )}
+                <div>{renderChildText(link)}</div>
               </div>
             </div>
-            <div className="notion-bookmark-image">
-              <img
-                src={blockValue.format.bookmark_cover}
-                alt={getTextContent(blockValue.properties.title)}
-              />
-            </div>
+            {bookmark_cover && (
+              <div className="notion-bookmark-image">
+                <img
+                  src={bookmark_cover}
+                  alt={getTextContent(title)}
+                />
+              </div>
+            )}
           </a>
         </div>
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,10 +110,10 @@ interface BookmarkValueType extends BaseValueType {
   type: "bookmark";
   properties: {
     link: DecorationType[];
-    title: DecorationType[];
-    description: DecorationType[];
+    title?: DecorationType[];
+    description?: DecorationType[];
   };
-  format: {
+  format?: {
     block_color?: string;
     bookmark_icon: string;
     bookmark_cover: string;


### PR DESCRIPTION
### Thanks for the cool package!

Fixes #18 
 
---
#### This is how it looks in notion.
(Sorry for the Japanese words mixed in with the examples.)
<img width="753" alt="スクリーンショット 2020-07-07 10 31 37" src="https://user-images.githubusercontent.com/38334778/86686234-21c12480-c03f-11ea-8e1a-d1480652b8c5.png">

The value when notion fails to fetch the bookmark.
```
{
  id: '{your_id}',
  version: 3,
  type: 'bookmark',
  properties: { link: [ [Array] ] },
  created_time: 1593341091859,
  last_edited_time: 1593341040000,
  parent_id: {your_id}',
  parent_table: 'block',
  alive: true,
  copied_from: '{your_id}'
  created_by_table: 'notion_user',
  created_by_id: '{your_id}'
  last_edited_by_table: 'notion_user',
  last_edited_by_id: '{your_id}'
  shard_id:'{your_id}'
  space_id: '{your_id}'
}

```

------

#### If you accept this PR, you will see this.
<img width="753" alt="スクリーンショット 2020-07-07 10 31 47" src="https://user-images.githubusercontent.com/38334778/86684551-9dba6d00-c03d-11ea-8c75-becc739cad32.png">
