### PR TITLE
Add support for Figma Embed Link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/block.tsx
+++ b/src/block.tsx
@@ -240,6 +240,7 @@ export const Block: React.FC<Block> = props => {
 
     case "image":
     case "embed":
+    case "figma":
     case "video":
       const value = block.value as ContentValueType;
 

--- a/src/components/asset.tsx
+++ b/src/components/asset.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { BlockType, ContentValueType, MapImageUrl } from "../types";
 
-const types = ["video", "image", "embed"];
+const types = ["video", "image", "embed", "figma"];
 
 const Asset: React.FC<{
   block: BlockType;
@@ -23,6 +23,22 @@ const Asset: React.FC<{
   } = format;
 
   const aspectRatio = block_aspect_ratio || block_height / block_width;
+
+  if (type === "figma") {
+    return (
+      <div
+        style={{
+          paddingBottom: `${aspectRatio * 100}%`,
+          position: "relative"
+        }}
+      >
+        <iframe
+          className="notion-image-inset"
+          src={value.properties.source[0][0]}
+        />
+      </div>
+    );
+  }
 
   if (type === "embed" || type === "video") {
     return (

--- a/src/components/asset.tsx
+++ b/src/components/asset.tsx
@@ -24,7 +24,7 @@ const Asset: React.FC<{
 
   const aspectRatio = block_aspect_ratio || block_height / block_width;
 
-  if (type === "figma") {
+  if (type === "embed" || type === "video" || type === "figma") {
     return (
       <div
         style={{
@@ -34,21 +34,8 @@ const Asset: React.FC<{
       >
         <iframe
           className="notion-image-inset"
-          src={value.properties.source[0][0]}
+          src={type === "figma" ? value.properties.source[0][0] : display_source}
         />
-      </div>
-    );
-  }
-
-  if (type === "embed" || type === "video") {
-    return (
-      <div
-        style={{
-          paddingBottom: `${aspectRatio * 100}%`,
-          position: "relative"
-        }}
-      >
-        <iframe className="notion-image-inset" src={display_source} />
       </div>
     );
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,6 +214,11 @@ interface ImageValueType extends ContentValueType {
 interface EmbedValueType extends ContentValueType {
   type: "embed";
 }
+
+interface FigmaValueType extends ContentValueType {
+  type: "figma";
+}
+
 interface VideoValueType extends ContentValueType {
   type: "video";
 }
@@ -273,6 +278,7 @@ export type BlockValueType =
   | ImageValueType
   | VideoValueType
   | EmbedValueType
+  | FigmaValueType
   | CalloutValueType
   | BookmarkValueType
   | ToggleValueType


### PR DESCRIPTION
Hi! First, this lib rocks! 🚀 

Second, I'm building my blog and realized some embed link were'nt supported yet. My plan was to send a PR for codepen, tweet and other assets, but only figma has `block.format.block_height` and `width` to calculate the aspect ratio.

This PR adds support for Figma embed links.

Screenshot of it:

<img width="825" alt="image" src="https://user-images.githubusercontent.com/9030018/89734120-7ab21d00-da30-11ea-8788-46e353d9877f.png">

