### PR TITLE
Sometimes ContentValueType values do not have a format

### DIFF
--- a/src/block.tsx
+++ b/src/block.tsx
@@ -246,7 +246,11 @@ export const Block: React.FC<Block> = props => {
       return (
         <figure
           className="notion-asset-wrapper"
-          style={{ width: value.format.block_width }}
+          style={
+            value.format !== undefined
+              ? { width: value.format.block_width }
+              : undefined
+          }
         >
           <Asset block={block} mapImageUrl={mapImageUrl} />
 

--- a/src/components/asset.tsx
+++ b/src/components/asset.tsx
@@ -16,11 +16,11 @@ const Asset: React.FC<{
 
   const format = value.format;
   const {
-    display_source,
-    block_aspect_ratio,
-    block_height,
-    block_width
-  } = format;
+    display_source = undefined,
+    block_aspect_ratio = undefined,
+    block_height = 1,
+    block_width = 1
+  } = format ?? {};
 
   const aspectRatio = block_aspect_ratio || block_height / block_width;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,7 +196,7 @@ export interface ContentValueType extends BaseValueType {
     source: string[][];
     caption?: DecorationType[];
   };
-  format: {
+  format?: {
     block_width: number;
     block_height: number;
     display_source: string;


### PR DESCRIPTION
Images pasted into Notion pages sometimes have an undefined format, which crashes the renderer.