### PR TITLE
Add text color to callout 

### DIFF
--- a/src/block.tsx
+++ b/src/block.tsx
@@ -421,19 +421,15 @@ export const Block: React.FC<Block> = props => {
             className={classNames(
               "notion-callout",
               blockValue.format.block_color &&
+                `notion-${blockValue.format.block_color}`,
+              blockValue.format.block_color &&
                 `notion-${blockValue.format.block_color}_co`
             )}
           >
             <div>
               <PageIcon block={block} mapImageUrl={mapImageUrl} />
             </div>
-            <div
-              className={classNames(
-                "notion-callout-text",
-                blockValue.format.block_color &&
-                  `notion-${blockValue.format.block_color}`
-              )}
-            >
+            <div className="notion-callout-text">
               {renderChildText(blockValue.properties.title)}
             </div>
           </div>

--- a/src/block.tsx
+++ b/src/block.tsx
@@ -427,7 +427,13 @@ export const Block: React.FC<Block> = props => {
             <div>
               <PageIcon block={block} mapImageUrl={mapImageUrl} />
             </div>
-            <div className="notion-callout-text">
+            <div
+              className={classNames(
+                "notion-callout-text",
+                blockValue.format.block_color &&
+                  `notion-${blockValue.format.block_color}`
+              )}
+            >
               {renderChildText(blockValue.properties.title)}
             </div>
           </div>


### PR DESCRIPTION
The text color of callouts is missing. Background color works, but there are no non-background `_co` css rules in `styles.css`, so text coloring of callouts does not work yet.

---

I fixed this by adding the same class without the `_co` before the existing class. This way the text color (first class) will not be overwritten (e.g. because no `.notion-teal_co` rule exists) and the background color will still use the custom `_co` rules (e.g. because `.notion-teal_backgorund` is overwritten by`.notion-teal_backgorund_co`)

You can see the working callout text color in the first block of this Notion page: `8c1ab01960b049f6a282dda64a94afc7`

