### PR TITLE
Show line breaks in callout text

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -496,6 +496,7 @@ img.notion-page-icon {
 }
 .notion-callout-text {
   margin-left: 8px;
+  white-space: pre-line;
 }
 
 .notion-toggle {


### PR DESCRIPTION
Callouts with line breaks weren't working _(i.e., line break rendered as space rather than new-line)_

---

Adding `white-space: pre-line;` to `.notion-callout-text` fixes this.

_Example page: `eb56261c0cff4f3496b2f33587ed6350`_