### PR TITLE
Pass currentBlock to CustomBlockComponent

### DIFF
--- a/src/block.tsx
+++ b/src/block.tsx
@@ -505,7 +505,7 @@ export const Block: React.FC<Block> = props => {
     return (
       <CustomComponent
         renderComponent={renderComponent}
-        block={block}
+        blockMap={blockMap}
         blockValue={blockValue as BlockValueProp<typeof blockValue.type>}
         level={level}
       >

--- a/src/block.tsx
+++ b/src/block.tsx
@@ -505,6 +505,7 @@ export const Block: React.FC<Block> = props => {
     return (
       <CustomComponent
         renderComponent={renderComponent}
+        block={block}
         blockValue={blockValue as BlockValueProp<typeof blockValue.type>}
         level={level}
       >

--- a/src/types.ts
+++ b/src/types.ts
@@ -346,7 +346,7 @@ export type BlockValueProp<T> = Extract<BlockValueType, { type: T }>;
 
 export interface CustomBlockComponentProps<T extends BlockValueTypeKeys> {
   renderComponent: () => JSX.Element | null;
-  block: BlockType;
+  blockMap: BlockMapType;
   blockValue: T extends BlockValueType ? BlockValueProp<T> : BaseValueType;
   level: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -346,6 +346,7 @@ export type BlockValueProp<T> = Extract<BlockValueType, { type: T }>;
 
 export interface CustomBlockComponentProps<T extends BlockValueTypeKeys> {
   renderComponent: () => JSX.Element | null;
+  block: BlockType;
   blockValue: T extends BlockValueType ? BlockValueProp<T> : BaseValueType;
   level: number;
 }


### PR DESCRIPTION
Previously, I can't create a custom block component for image because I can't access the parent block of the image.

```ts
<NotionRenderer
    blockMap={notionBlocks ?? {}}
    customBlockComponents={{
        image: ({ blockValue }) => {
            // Image cannot be loaded because it need the parent and file id
            const src = defaultMapImageUrl(
                blockValue.properties.source[0][0]
            );
            const caption = blockValue.properties.caption?.[0][0];
            return (
                <figure>
                    <div>
                        <img src={src} alt={caption} />
                    </div>
                </figure>
            );
        },
    }}
/>
```

With this changes, now I can do the following:

```ts
<NotionRenderer
    blockMap={notionBlocks ?? {}}
    customBlockComponents={{
        // NOTE: currentBlock now passed to this custom component
        image: ({ block, blockValue }) => {
            const src = defaultMapImageUrl(
                blockValue.properties.source[0][0],
                block
            );
            const caption = blockValue.properties.caption?.[0][0];
            return (
                <figure>
                    <div>
                        <img src={src} alt={caption} />
                    </div>
                </figure>
            );
        },
    }}
/>
```

Now the image can be loaded correctly in CustomBlockComponent.