### PR TITLE
Add strict rendering mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ export default ({ blockMap }) => (
 );
 ```
 
+### Strict Mode
+
+`NotionRenderer` will do its best to render your page, but in some cases it may not be able to render all content. By default, if content cannot be displayed, it will be omitted from the final render but as much content as possible will still be displayed. `strict` mode throws an error in cases like this, causing the entire render to fail if any page content cannot be displayed.
+
+```js
+<NotionRenderer blockMap={blockMap} strict={true} />
+```
+
 ## Sites using react-notion
 
 List of pages that implement this library.

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -20,6 +20,8 @@ export interface NotionRendererProps {
   level?: number;
   customBlockComponents?: CustomBlockComponents;
   customDecoratorComponents?: CustomDecoratorComponents;
+
+  strict?: boolean;
 }
 
 export const NotionRenderer: React.FC<NotionRendererProps> = ({
@@ -27,6 +29,7 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
   currentId,
   mapPageUrl = defaultMapPageUrl,
   mapImageUrl = defaultMapImageUrl,
+  strict = false,
   ...props
 }) => {
   const { blockMap } = props;
@@ -34,8 +37,12 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
   const currentBlock = blockMap[id];
 
   if (!currentBlock) {
+    const errorMessage = `error rendering block ${currentId}: block not in blockMap`;
+    if (strict) {
+      throw new Error(errorMessage);
+    }
     if (process.env.NODE_ENV !== "production") {
-      console.warn("error rendering block", currentId);
+      console.warn(errorMessage);
     }
     return null;
   }
@@ -56,6 +63,7 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
           level={level + 1}
           mapPageUrl={mapPageUrl}
           mapImageUrl={mapImageUrl}
+          strict={strict}
           {...props}
         />
       ))}


### PR DESCRIPTION
### Strict Mode

`NotionRenderer` will do its best to render your page, but in some cases it may not be able to render all content. By default, if content cannot be displayed, it will be omitted from the final render but as much content as possible will still be displayed. `strict` mode throws an error in cases like this, causing the entire render to fail if any page content cannot be displayed.

```js
<NotionRenderer blockMap={blockMap} strict={true} />
```

**Use case**: rendering legal documents.

## Related

* https://github.com/splitbee/notion-api-worker/issues/41