### PR TITLE
Update asset.tsx to use always use value.properties.source[0][0]

### DIFF
--- a/src/components/asset.tsx
+++ b/src/components/asset.tsx
@@ -35,7 +35,7 @@ const Asset: React.FC<{
         <iframe
           className="notion-image-inset"
           src={
-            type === "figma" ? value.properties.source[0][0] : display_source
+            value.properties.source[0][0]
           }
         />
       </div>


### PR DESCRIPTION
There are some cases in embed blocks where `format.display_source` doesn't exist. `value.properties.source[0][0]` should always exist, therefore this is the property that should be used always.