### PR TITLE
Feat: Use Alt Property for Image Blocks

### DIFF
--- a/src/components/asset.tsx
+++ b/src/components/asset.tsx
@@ -45,6 +45,7 @@ const Asset: React.FC<{
   if (block.value.type === "image") {
     const src = mapImageUrl(value.properties.source[0][0], block);
     const caption = value.properties.caption?.[0][0];
+    const altText = value.properties.alt_text?.[0][0];
 
     if (block_aspect_ratio) {
       return (
@@ -56,7 +57,7 @@ const Asset: React.FC<{
         >
           <img
             className="notion-image-inset"
-            alt={caption || "notion image"}
+            alt={altText || caption || "notion image"}
             src={src}
           />
         </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,6 +197,7 @@ export interface ContentValueType extends BaseValueType {
   properties: {
     source: string[][];
     caption?: DecorationType[];
+    alt_text?: string[][];
   };
   format?: {
     block_width: number;


### PR DESCRIPTION
Hello,

I added support to utilise the alt property for the image blocks. For websites where SEO is important (and where there is no need for a visible caption), I believe this feature is essential.

@tobiaslins 